### PR TITLE
Fix: Handle invalid data path on startup

### DIFF
--- a/codici/python/app/main.py
+++ b/codici/python/app/main.py
@@ -1,24 +1,22 @@
 import sys
+import os
 from pathlib import Path
 
 # Add the parent directory ('codici/python') to the system path
-# This allows us to import from both 'app' and 'tools' packages
-sys.path.append(str(Path(__file__).parent.parent))
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from app.controllers.quiz_controller import QuizController
 from app.services.settings_manager import SettingsManager
 from app.services.config_manager import ConfigManager
 from app.views.main_view import MainView
+from app.views.path_dialog import ask_for_new_datapath
 
-class App:
-    def __init__(self):
-        # 1. Initialize core logic components, starting with the new ConfigManager
+def launch_app():
+    """Lancia l'applicazione principale."""
+    try:
         config_manager = ConfigManager()
         settings_manager = SettingsManager(config_manager)
 
-        # 2. Create the main window (View)
-        # The view is created first, but it's just a UI shell at this point.
-        # The controller is passed in as a lambda to avoid circular dependencies
         main_window = MainView(
             start_callback=lambda mode: controller.start(mode),
             settings_callback=lambda: controller.open_settings(),
@@ -30,12 +28,27 @@ class App:
             }
         )
 
-        # 3. Create the Controller, linking the View and all managers together
         controller = QuizController(main_window, settings_manager, config_manager)
-
-        # 4. Perform initial checks and start the main loop
         main_window.after(100, controller.update_dashboard_and_srs_status)
         main_window.mainloop()
 
+    except FileNotFoundError as e:
+        # Errore specifico catturato quando il data_path non è valido
+        config_manager = ConfigManager()
+        invalid_path = config_manager.get_data_path()
+
+        new_path = ask_for_new_datapath(invalid_path)
+
+        if new_path:
+            # Aggiorna il profilo attivo con il nuovo percorso
+            active_profile = config_manager.get_active_profile()
+            config_manager.update_profile_path(active_profile, str(new_path))
+
+            # Riavvia l'applicazione per applicare le modifiche
+            os.execv(sys.executable, ['python'] + sys.argv)
+        else:
+            # L'utente ha annullato, l'applicazione si chiude
+            sys.exit(0)
+
 if __name__ == "__main__":
-    app = App()
+    launch_app()

--- a/codici/python/app/views/path_dialog.py
+++ b/codici/python/app/views/path_dialog.py
@@ -1,0 +1,48 @@
+import tkinter as tk
+from tkinter import filedialog, messagebox
+from pathlib import Path
+
+def ask_for_new_datapath(invalid_path: Path) -> Path | None:
+    """
+    Mostra un dialogo di errore e chiede all'utente di selezionare una nuova cartella dati.
+
+    Args:
+        invalid_path: Il percorso non valido che ha causato l'errore.
+
+    Returns:
+        Un nuovo percorso Path valido se selezionato, altrimenti None.
+    """
+    # Nasconde la finestra root principale di Tkinter
+    root = tk.Tk()
+    root.withdraw()
+
+    # Messaggio di errore
+    error_message = (
+        f"Il percorso dati configurato non è stato trovato o non è accessibile:\n\n"
+        f"{invalid_path}\n\n"
+        "Potrebbe essere necessario collegare un'unità esterna o selezionare una nuova cartella."
+    )
+
+    # Mostra un avviso e chiede se l'utente vuole scegliere una nuova cartella
+    response = messagebox.askokcancel(
+        "Percorso Dati Non Valido",
+        f"{error_message}\n\nVuoi scegliere una nuova cartella dati?"
+    )
+
+    if not response:
+        # L'utente ha premuto "Annulla"
+        messagebox.showinfo("Uscita", "L'applicazione verrà chiusa.")
+        return None
+
+    # Apre il selettore di cartelle
+    new_path_str = filedialog.askdirectory(
+        title="Seleziona la Nuova Cartella Dati",
+        initialdir=Path.home()  # Parte dalla home dell'utente per comodità
+    )
+
+    if not new_path_str:
+        # L'utente ha chiuso il selettore di cartelle
+        messagebox.showinfo("Uscita", "Nessuna cartella selezionata. L'applicazione verrà chiusa.")
+        return None
+
+    return Path(new_path_str)


### PR DESCRIPTION
This commit resolves an application crash that occurred when the configured data path was not found or accessible (e.g., a disconnected network drive).

Instead of crashing with a FileNotFoundError, the application now:
1. Catches the error during startup.
2. Displays a dialog informing the user about the invalid path.
3. Prompts the user to select a new, valid data directory.
4. Updates the configuration with the new path.
5. Restarts itself to apply the new settings.

This makes the application more robust and portable, allowing users to easily switch between different machines and configurations without manual file editing.