### PR TITLE
Fix: Correct leech warning logic

### DIFF
--- a/codici/python/app/controllers/quiz_controller.py
+++ b/codici/python/app/controllers/quiz_controller.py
@@ -403,7 +403,10 @@ class QuizController:
         q = self.active_questions[self.current_question_index]
         self.srs_session_results.append(rating != "non_la_sapevo")
         if self.srs_manager:
-            if self.srs_manager.update_after_review(q, rating, q.time_taken):
+            # Aggiorna la domanda e controlla se è diventata una leech
+            is_leech = self.srs_manager.update_after_review(q, rating, q.time_taken)
+            # Mostra l'avviso solo se la domanda è una leech E l'utente ha appena risposto "non la sapevo"
+            if is_leech and rating == "non_la_sapevo":
                 messagebox.showwarning("Attenzione: Domanda Ostica!", f"Continui ad avere difficoltà con questa domanda. Prova a studiarla da una fonte diversa.\n\n- {q.text[:100]}...")
         self.next_question()
 


### PR DESCRIPTION
This commit fixes a bug where the "Domanda Ostica" (leech question) warning was displayed incorrectly. Previously, the warning would appear for any leech question, even if the user rated it as "Easy".

The logic in `quiz_controller.py` has been updated to ensure the warning is only shown when both of the following conditions are true:
1. The question is identified as a leech by the SRS manager.
2. The user explicitly rates the question as "non_la_sapevo" (I didn't know).

This change aligns the application's behavior with the user's expectation, providing a more accurate and less confusing user experience.